### PR TITLE
e2eテストがランダムにコケるのを修正

### DIFF
--- a/cypress/integration/basic.js
+++ b/cypress/integration/basic.js
@@ -1,5 +1,8 @@
 describe('Before setup instance', () => {
 	beforeEach(() => {
+		cy.window(win => {
+			win.indexedDB.deleteDatabase('keyval-store');
+		});
 		cy.request('POST', '/api/reset-db').as('reset');
 		cy.get('@reset').its('status').should('equal', 204);
 		cy.reload(true);
@@ -32,6 +35,9 @@ describe('Before setup instance', () => {
 
 describe('After setup instance', () => {
 	beforeEach(() => {
+		cy.window(win => {
+			win.indexedDB.deleteDatabase('keyval-store');
+		});
 		cy.request('POST', '/api/reset-db').as('reset');
 		cy.get('@reset').its('status').should('equal', 204);
 		cy.reload(true);
@@ -70,6 +76,9 @@ describe('After setup instance', () => {
 
 describe('After user signup', () => {
 	beforeEach(() => {
+		cy.window(win => {
+			win.indexedDB.deleteDatabase('keyval-store');
+		});
 		cy.request('POST', '/api/reset-db').as('reset');
 		cy.get('@reset').its('status').should('equal', 204);
 		cy.reload(true);
@@ -129,6 +138,9 @@ describe('After user signup', () => {
 
 describe('After user singed in', () => {
 	beforeEach(() => {
+		cy.window(win => {
+			win.indexedDB.deleteDatabase('keyval-store');
+		});
 		cy.request('POST', '/api/reset-db').as('reset');
 		cy.get('@reset').its('status').should('equal', 204);
 		cy.reload(true);
@@ -163,12 +175,10 @@ describe('After user singed in', () => {
 	});
 
   it('successfully loads', () => {
-    cy.visit('/');
+		cy.get('[data-cy-open-post-form]').should('be.visible');
   });
 
 	it('note', () => {
-    cy.visit('/');
-
 		cy.get('[data-cy-open-post-form]').click();
 		cy.get('[data-cy-post-form-text]').type('Hello, Misskey!');
 		cy.get('[data-cy-open-post-form-submit]').click();

--- a/packages/backend/src/db/postgre.ts
+++ b/packages/backend/src/db/postgre.ts
@@ -3,6 +3,7 @@ const types = require('pg').types;
 types.setTypeParser(20, Number);
 
 import { createConnection, Logger, getConnection } from 'typeorm';
+import { redisClient } from './redis';
 import * as highlight from 'cli-highlight';
 import config from '@/config/index';
 
@@ -218,6 +219,7 @@ export function initDb(justBorrow = false, sync = false, forceRecreate = false) 
 
 export async function resetDb() {
 	const reset = async () => {
+		await redisClient.FLUSHDB();
 		const conn = await getConnection();
 		const tables = await conn.query(`SELECT relname AS "table"
 		FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)

--- a/packages/backend/src/misc/fetch-meta.ts
+++ b/packages/backend/src/misc/fetch-meta.ts
@@ -18,9 +18,16 @@ export async function fetchMeta(noCache = false): Promise<Meta> {
 			cache = meta;
 			return meta;
 		} else {
-			const saved = await transactionalEntityManager.save(Meta, {
-				id: 'x',
-			}) as Meta;
+			// metaが空のときfetchMetaが同時に呼ばれるとここが同時に呼ばれてしまうことがあるのでフェイルセーフなupsertを使う
+			const saved = await transactionalEntityManager
+				.upsert(
+					Meta,
+					{
+						id: 'x',
+					},
+					['id'],
+				)
+				.then((x) => transactionalEntityManager.findOneByOrFail(Meta, x.identifiers[0]));
 
 			cache = saved;
 			return saved;

--- a/packages/backend/src/misc/fetch-meta.ts
+++ b/packages/backend/src/misc/fetch-meta.ts
@@ -27,7 +27,7 @@ export async function fetchMeta(noCache = false): Promise<Meta> {
 					},
 					['id'],
 				)
-				.then((x) => transactionalEntityManager.findOneByOrFail(Meta, x.identifiers[0]));
+				.then((x) => transactionalEntityManager.findOneOrFail(Meta, x.identifiers[0])) as Meta;
 
 			cache = saved;
 			return saved;


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/issues/7986

* test: indexeddbをテスト毎に初期化するように
* fix: metaが無いときにfetch-metaを同時に呼ぶと死ぬことがある問題を修正
* test: ログイン後のクライアント側処理を待たずにリロードされてログイン出来ないことがあったのを修正
* test: redisをテスト毎に初期化するように

<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
